### PR TITLE
[Fix] fix adam target parameters

### DIFF
--- a/notebooks/pusht/pusht.ipynb
+++ b/notebooks/pusht/pusht.ipynb
@@ -1512,7 +1512,7 @@
     "# Standard ADAM optimizer\n",
     "# Note that EMA parametesr are not optimized\n",
     "optimizer = torch.optim.AdamW(\n",
-    "    params=sfp_velocity_net.parameters(),\n",
+    "    params=dp_noise_pred_net.parameters(),\n",
     "    lr=1e-4, weight_decay=1e-6)\n",
     "\n",
     "# Cosine LR schedule with linear warmup\n",


### PR DESCRIPTION
I found a bug in the Push T training notebook. The Adam target parameters for the diffusion policy should come from the `dp_noise_pred_net`. Please feel free to let me know if I misunderstand something.