### PR TITLE
Add EqM-E regularisation and 2D bimodal toy experiment

### DIFF
--- a/streaming_flow_policy/pusht/dataset_2d_toy.py
+++ b/streaming_flow_policy/pusht/dataset_2d_toy.py
@@ -1,0 +1,170 @@
+"""
+2D bimodal toy dataset for SFP experiments.
+
+Two demonstration modes:
+  Mode A (S-curve):      x = t, y =  0.8 * sin(π*(2t-1))   [t ∈ [0, 1]]
+  Mode B (anti-S-curve): x = t, y = -0.8 * sin(π*(2t-1))   [t ∈ [0, 1]]
+
+Both curves start at (0, 0) and end at (1, 0), but trace different paths,
+creating a bimodal distribution ideal for testing multi-modal imitation learning.
+
+The __getitem__ format matches PushTStateDataset:
+    'obs'    (OBS_HORIZON, 2)   – position history window
+    'action' (PRED_HORIZON, 2)  – future positions to predict
+"""
+from typing import Callable, Dict, Optional
+
+import numpy as np
+import torch
+
+from streaming_flow_policy.pusht.dp_state_notebook.dataset import (
+    create_sample_indices,
+    get_data_stats,
+    normalize_data,
+    sample_sequence,
+    unnormalize_data,
+)
+
+
+def generate_trajectory(mode: str, T: int = 60) -> np.ndarray:
+    """Generate a clean 2D S-curve or anti-S-curve trajectory.
+
+    Args:
+        mode: 's' for S-curve, 'anti_s' for reverse S-curve.
+        T: number of timesteps.
+
+    Returns:
+        np.ndarray shape (T, 2): trajectory positions (x, y).
+    """
+    t = np.linspace(0, 1, T, dtype=np.float32)
+    x = t
+    sign = 1.0 if mode == 's' else -1.0
+    y = sign * 0.8 * np.sin(np.pi * (2.0 * t - 1.0)).astype(np.float32)
+    return np.stack([x, y], axis=1)  # (T, 2)
+
+
+class ToyDataset2D(torch.utils.data.Dataset):
+    """2D bimodal toy dataset compatible with StreamingFlowPolicyStochastic.
+
+    Parameters
+    ----------
+    pred_horizon:
+        Number of future actions to predict (sequence window length).
+    obs_horizon:
+        Number of past observations to condition on (must be 2 for SFP).
+    action_horizon:
+        Number of executed actions per step (used for index padding only).
+    n_episodes_per_mode:
+        How many independent episodes to generate per mode.
+    steps_per_episode:
+        Trajectory length of each episode (should be > pred_horizon).
+    noise_std:
+        Standard deviation of Gaussian noise added to each episode to
+        diversify demonstrations.
+    transform_datum_fn:
+        Optional function applied to each raw {'obs', 'action'} sample,
+        e.g. StreamingFlowPolicyStochastic.TransformTrainingDatum.
+    seed:
+        Random seed for reproducibility.
+    """
+
+    def __init__(
+        self,
+        pred_horizon: int = 16,
+        obs_horizon: int = 2,
+        action_horizon: int = 8,
+        n_episodes_per_mode: int = 100,
+        steps_per_episode: int = 60,
+        noise_std: float = 0.01,
+        transform_datum_fn: Optional[Callable] = None,
+        seed: int = 42,
+    ):
+        assert obs_horizon == 2, "SFP currently requires obs_horizon == 2"
+        assert steps_per_episode > pred_horizon, (
+            "steps_per_episode must exceed pred_horizon to allow at least one window."
+        )
+
+        self.pred_horizon = pred_horizon
+        self.obs_horizon = obs_horizon
+        self.action_horizon = action_horizon
+        self.transform_datum_fn = transform_datum_fn
+
+        rng = np.random.default_rng(seed)
+
+        all_obs: list = []
+        all_actions: list = []
+        episode_ends: list = []
+        cursor = 0
+
+        for mode in ('s', 'anti_s'):
+            for _ in range(n_episodes_per_mode):
+                traj = generate_trajectory(mode, steps_per_episode)  # (T, 2)
+
+                # Small per-episode noise keeps demonstrations diverse while
+                # preserving the overall bimodal shape.
+                traj = traj + rng.normal(0.0, noise_std, traj.shape).astype(np.float32)
+
+                # obs[i]    = position at step i
+                # action[i] = position at step i+1  (next-obs as action)
+                obs_ep = traj                                           # (T, 2)
+                action_ep = np.concatenate(
+                    [traj[1:], traj[[-1]]], axis=0
+                ).astype(np.float32)                                    # (T, 2)
+
+                all_obs.append(obs_ep)
+                all_actions.append(action_ep)
+                cursor += steps_per_episode
+                episode_ends.append(cursor)
+
+        obs_arr = np.concatenate(all_obs, axis=0)       # (N_total, 2)
+        action_arr = np.concatenate(all_actions, axis=0)  # (N_total, 2)
+        episode_ends_arr = np.array(episode_ends, dtype=np.int64)
+
+        train_data: Dict[str, np.ndarray] = {
+            'obs': obs_arr,
+            'action': action_arr,
+        }
+
+        # Normalize each key independently to [-1, 1].
+        stats: Dict = {}
+        normalized: Dict[str, np.ndarray] = {}
+        for key, data in train_data.items():
+            stats[key] = get_data_stats(data)
+            normalized[key] = normalize_data(data, stats[key])
+
+        indices = create_sample_indices(
+            episode_ends=episode_ends_arr,
+            sequence_length=pred_horizon,
+            pad_before=obs_horizon - 1,
+            pad_after=action_horizon - 1,
+        )
+
+        self.stats = stats
+        self.normalized_train_data = normalized
+        self.indices = indices
+
+    # ------------------------------------------------------------------
+    # Dataset protocol
+    # ------------------------------------------------------------------
+
+    def __len__(self) -> int:
+        return len(self.indices)
+
+    def __getitem__(self, idx: int) -> Dict:
+        buf_start, buf_end, samp_start, samp_end = self.indices[idx]
+
+        nsample = sample_sequence(
+            train_data=self.normalized_train_data,
+            sequence_length=self.pred_horizon,
+            buffer_start_idx=buf_start,
+            buffer_end_idx=buf_end,
+            sample_start_idx=samp_start,
+            sample_end_idx=samp_end,
+        )
+        # Keep only the obs_horizon most recent observations.
+        nsample['obs'] = nsample['obs'][:self.obs_horizon, :]  # (OBS_HORIZON, 2)
+
+        if self.transform_datum_fn is not None:
+            nsample = self.transform_datum_fn(nsample)
+
+        return nsample

--- a/streaming_flow_policy/pusht/experiments/toy_2d/train_and_plot.py
+++ b/streaming_flow_policy/pusht/experiments/toy_2d/train_and_plot.py
@@ -1,0 +1,378 @@
+"""
+2D Toy Comparison: DP  vs  SFP  vs  SFP + EqM-E
+=================================================
+
+Trains three models on the bimodal 2D toy dataset, then draws a side-by-side
+comparison plot showing how well each method covers both modes.
+
+Usage
+-----
+    cd <repo-root>
+    python -m streaming_flow_policy.pusht.experiments.toy_2d.train_and_plot
+
+Output
+------
+    toy_2d_comparison.png  — comparison figure saved to the working directory.
+"""
+import os
+import numpy as np
+import torch
+import torch.nn as nn
+import matplotlib.pyplot as plt
+import matplotlib.patches as mpatches
+from diffusers.schedulers.scheduling_ddpm import DDPMScheduler
+from diffusers.training_utils import EMAModel
+from diffusers.optimization import get_scheduler
+from tqdm.auto import tqdm
+
+from streaming_flow_policy.pusht.dataset_2d_toy import ToyDataset2D, generate_trajectory
+from streaming_flow_policy.pusht.dp_state_notebook.network import ConditionalUnet1D
+from streaming_flow_policy.pusht.dp_state_notebook.dataset import (
+    normalize_data, unnormalize_data,
+)
+from streaming_flow_policy.pusht.dp_state_notebook.diffusion_policy import DiffusionPolicy
+from streaming_flow_policy.pusht.sfps import StreamingFlowPolicyStochastic
+
+# ============================================================================
+# Hyper-parameters
+# ============================================================================
+
+PRED_HORIZON     = 16
+OBS_HORIZON      = 2
+ACTION_HORIZON   = 8
+OBS_DIM          = 2
+ACTION_DIM       = 2
+
+# Training
+NUM_EPOCHS       = 500
+BATCH_SIZE       = 256
+LR               = 1e-4
+WEIGHT_DECAY     = 1e-6
+WARMUP_STEPS     = 200
+
+# SFP
+SIGMA_0          = 0.0
+SIGMA_1          = 0.1
+EQME_LAMBDA      = 0.01   # weight for EqM-E regulariser
+
+# Diffusion Policy
+NUM_DIFFUSION_ITERS = 100
+
+# Evaluation
+N_ROLLOUTS       = 50   # number of generated trajectories per method
+
+DOWN_DIMS        = [128, 256, 512]   # smaller net for 2D toy
+
+# Device selection — torchdyn NeuralODE works reliably on CPU/CUDA.
+# MPS can be used for DP but may be unstable for ODE solvers.
+if torch.cuda.is_available():
+    DEVICE = torch.device('cuda')
+elif torch.backends.mps.is_available():
+    DEVICE = torch.device('mps')
+else:
+    DEVICE = torch.device('cpu')
+
+print(f"Using device: {DEVICE}")
+
+# ============================================================================
+# Helper: build starting observation from the first frame of both modes
+# ============================================================================
+
+def make_start_obs(stats, device):
+    """Return a normalized (OBS_HORIZON, OBS_DIM) obs starting at (0, 0)."""
+    start_pos = np.array([[0.0, 0.0], [0.0, 0.0]], dtype=np.float32)  # (2, 2)
+    nobs = normalize_data(start_pos, stats['obs'])
+    return torch.from_numpy(nobs).to(device)
+
+
+# ============================================================================
+# Helper: run N rollouts of an SFP policy
+# ============================================================================
+
+def rollout_sfp(policy, nobs, n_rollouts, stats):
+    """Return unnormalized trajectories shape (n_rollouts, PRED_HORIZON, 2)."""
+    trajs = []
+    for _ in range(n_rollouts):
+        with torch.no_grad():
+            naction = policy(nobs, num_actions=PRED_HORIZON)  # (1, T, 2)
+        traj = unnormalize_data(
+            naction.squeeze(0).cpu().numpy(), stats['action']
+        )  # (T, 2)
+        trajs.append(traj)
+    return np.stack(trajs)  # (N, T, 2)
+
+
+# ============================================================================
+# Helper: run N rollouts of a DP policy
+# ============================================================================
+
+def rollout_dp(policy, nobs, n_rollouts, stats):
+    """Return unnormalized trajectories shape (n_rollouts, PRED_HORIZON, 2)."""
+    trajs = []
+    for _ in range(n_rollouts):
+        with torch.no_grad():
+            naction = policy(nobs)  # (1, T, 2)
+        traj = unnormalize_data(
+            naction.squeeze(0).cpu().numpy(), stats['action']
+        )  # (T, 2)
+        trajs.append(traj)
+    return np.stack(trajs)  # (N, T, 2)
+
+
+# ============================================================================
+# Training helpers
+# ============================================================================
+
+def make_sfp_policy(eqme_lambda=0.0):
+    net = ConditionalUnet1D(
+        input_dim=ACTION_DIM,
+        global_cond_dim=OBS_DIM * OBS_HORIZON,
+        down_dims=DOWN_DIMS,
+        fc_timesteps=2,   # SFP processes [a, z] — a 2-step sequence
+    ).to(DEVICE)
+    policy = StreamingFlowPolicyStochastic(
+        velocity_net=net,
+        action_dim=ACTION_DIM,
+        σ0=SIGMA_0,
+        σ1=SIGMA_1,
+        pred_horizon=PRED_HORIZON,
+        eqme_lambda=eqme_lambda,
+        device=DEVICE,
+    )
+    return policy, net
+
+
+def train_sfp(policy, net, dataset, label):
+    """Train an SFP (or SFP+EqM-E) model. Returns the EMA-averaged policy."""
+    dataloader = torch.utils.data.DataLoader(
+        dataset,
+        batch_size=BATCH_SIZE,
+        shuffle=True,
+        num_workers=0,
+        pin_memory=(DEVICE.type == 'cuda'),
+    )
+
+    ema = EMAModel(parameters=net.parameters(), power=0.75)
+    optimizer = torch.optim.AdamW(net.parameters(), lr=LR, weight_decay=WEIGHT_DECAY)
+    lr_scheduler = get_scheduler(
+        'cosine',
+        optimizer=optimizer,
+        num_warmup_steps=WARMUP_STEPS,
+        num_training_steps=len(dataloader) * NUM_EPOCHS,
+    )
+
+    with tqdm(range(NUM_EPOCHS), desc=label) as tglobal:
+        for _ in tglobal:
+            epoch_losses = []
+            for nbatch in dataloader:
+                loss = policy.Loss(nbatch)
+                loss.backward()
+                optimizer.step()
+                optimizer.zero_grad()
+                lr_scheduler.step()
+                ema.step(net.parameters())
+                epoch_losses.append(loss.item())
+            tglobal.set_postfix(loss=np.mean(epoch_losses))
+
+    ema.copy_to(net.parameters())
+    return policy
+
+
+def make_dp_policy():
+    net = ConditionalUnet1D(
+        input_dim=ACTION_DIM,
+        global_cond_dim=OBS_DIM * OBS_HORIZON,
+        down_dims=DOWN_DIMS,
+    ).to(DEVICE)
+    noise_scheduler = DDPMScheduler(
+        num_train_timesteps=NUM_DIFFUSION_ITERS,
+        beta_schedule='squaredcos_cap_v2',
+        clip_sample=True,
+        prediction_type='epsilon',
+    )
+    policy = DiffusionPolicy(
+        noise_pred_net=net,
+        num_diffusion_iters=NUM_DIFFUSION_ITERS,
+        pred_horizon=PRED_HORIZON,
+        action_dim=ACTION_DIM,
+        device=DEVICE,
+    )
+    return policy, net, noise_scheduler
+
+
+def train_dp(policy, net, noise_scheduler, dataset, label):
+    """Train a Diffusion Policy model. Returns the EMA-averaged policy."""
+    dataloader = torch.utils.data.DataLoader(
+        dataset,
+        batch_size=BATCH_SIZE,
+        shuffle=True,
+        num_workers=0,
+        pin_memory=(DEVICE.type == 'cuda'),
+    )
+
+    ema = EMAModel(parameters=net.parameters(), power=0.75)
+    optimizer = torch.optim.AdamW(net.parameters(), lr=LR, weight_decay=WEIGHT_DECAY)
+    lr_scheduler = get_scheduler(
+        'cosine',
+        optimizer=optimizer,
+        num_warmup_steps=WARMUP_STEPS,
+        num_training_steps=len(dataloader) * NUM_EPOCHS,
+    )
+
+    with tqdm(range(NUM_EPOCHS), desc=label) as tglobal:
+        for _ in tglobal:
+            epoch_losses = []
+            for nbatch in dataloader:
+                nobs    = nbatch['obs'].to(DEVICE)     # (B, OBS_HORIZON, OBS_DIM)
+                naction = nbatch['action'].to(DEVICE)  # (B, PRED_HORIZON, ACTION_DIM)
+                B = nobs.shape[0]
+
+                obs_cond = nobs[:, :OBS_HORIZON, :].flatten(start_dim=1)
+                noise    = torch.randn_like(naction)
+                timesteps = torch.randint(
+                    0, noise_scheduler.config.num_train_timesteps,
+                    (B,), device=DEVICE,
+                ).long()
+                noisy_actions = noise_scheduler.add_noise(naction, noise, timesteps)
+                noise_pred    = net(noisy_actions, timesteps, global_cond=obs_cond)
+                loss          = nn.functional.mse_loss(noise_pred, noise)
+
+                loss.backward()
+                optimizer.step()
+                optimizer.zero_grad()
+                lr_scheduler.step()
+                ema.step(net.parameters())
+                epoch_losses.append(loss.item())
+            tglobal.set_postfix(loss=np.mean(epoch_losses))
+
+    ema.copy_to(net.parameters())
+    return policy
+
+
+# ============================================================================
+# Main
+# ============================================================================
+
+def main():
+    # ------------------------------------------------------------------
+    # Datasets
+    # ------------------------------------------------------------------
+    # DP dataset: raw {obs, action} (no transform_datum_fn)
+    dp_dataset = ToyDataset2D(
+        pred_horizon=PRED_HORIZON,
+        obs_horizon=OBS_HORIZON,
+        action_horizon=ACTION_HORIZON,
+    )
+    stats = dp_dataset.stats  # shared normalisation stats
+
+    # SFP datasets: apply TransformTrainingDatum inside __getitem__
+    sfp_policy_tmp, _ = make_sfp_policy(eqme_lambda=0.0)
+    sfp_dataset = ToyDataset2D(
+        pred_horizon=PRED_HORIZON,
+        obs_horizon=OBS_HORIZON,
+        action_horizon=ACTION_HORIZON,
+        transform_datum_fn=sfp_policy_tmp.TransformTrainingDatum,
+    )
+    # Re-use the same data for SFP+EqM-E; TransformTrainingDatum is stateless
+    # so we can share the dataset object.
+
+    # ------------------------------------------------------------------
+    # Train DP
+    # ------------------------------------------------------------------
+    print("\n=== Training DP baseline ===")
+    dp_policy, dp_net, dp_scheduler = make_dp_policy()
+    train_dp(dp_policy, dp_net, dp_scheduler, dp_dataset, label="DP")
+
+    # ------------------------------------------------------------------
+    # Train SFP (no EqM-E)
+    # ------------------------------------------------------------------
+    print("\n=== Training SFP (no EqM-E) ===")
+    sfp_policy, sfp_net = make_sfp_policy(eqme_lambda=0.0)
+    # Recreate dataset with the new policy's transform function
+    sfp_dataset_plain = ToyDataset2D(
+        pred_horizon=PRED_HORIZON,
+        obs_horizon=OBS_HORIZON,
+        action_horizon=ACTION_HORIZON,
+        transform_datum_fn=sfp_policy.TransformTrainingDatum,
+    )
+    train_sfp(sfp_policy, sfp_net, sfp_dataset_plain, label="SFP")
+
+    # ------------------------------------------------------------------
+    # Train SFP + EqM-E
+    # ------------------------------------------------------------------
+    print(f"\n=== Training SFP + EqM-E (λ={EQME_LAMBDA}) ===")
+    sfp_eqme_policy, sfp_eqme_net = make_sfp_policy(eqme_lambda=EQME_LAMBDA)
+    sfp_dataset_eqme = ToyDataset2D(
+        pred_horizon=PRED_HORIZON,
+        obs_horizon=OBS_HORIZON,
+        action_horizon=ACTION_HORIZON,
+        transform_datum_fn=sfp_eqme_policy.TransformTrainingDatum,
+    )
+    train_sfp(sfp_eqme_policy, sfp_eqme_net, sfp_dataset_eqme, label="SFP+EqM-E")
+
+    # ------------------------------------------------------------------
+    # Evaluate: generate rollouts from the shared starting observation
+    # ------------------------------------------------------------------
+    nobs = make_start_obs(stats, DEVICE)  # (OBS_HORIZON, OBS_DIM)
+
+    print("\nGenerating rollouts …")
+    dp_trajs   = rollout_dp(dp_policy,   nobs, N_ROLLOUTS, stats)
+    sfp_trajs  = rollout_sfp(sfp_policy, nobs, N_ROLLOUTS, stats)
+    eqme_trajs = rollout_sfp(sfp_eqme_policy, nobs, N_ROLLOUTS, stats)
+
+    # Ground-truth demo trajectories (unnormalized)
+    demo_s     = generate_trajectory('s',     T=PRED_HORIZON)
+    demo_anti  = generate_trajectory('anti_s', T=PRED_HORIZON)
+
+    # ------------------------------------------------------------------
+    # Plot
+    # ------------------------------------------------------------------
+    fig, axes = plt.subplots(1, 4, figsize=(18, 4.5), sharex=True, sharey=True)
+    fig.suptitle("2D Toy Comparison: Bimodal Coverage", fontsize=14, fontweight='bold')
+
+    titles  = ["Ground Truth Demos", "DP baseline", "SFP", f"SFP + EqM-E (λ={EQME_LAMBDA})"]
+    c_s     = '#2196F3'   # blue  — S-curve
+    c_anti  = '#F44336'   # red   — anti-S-curve
+    c_gen   = '#9E9E9E'   # grey  — generated
+
+    for ax, title in zip(axes, titles):
+        # Always draw the true demos as reference
+        ax.plot(demo_s[:, 0],    demo_s[:, 1],    color=c_s,   lw=2, label='S-curve demo')
+        ax.plot(demo_anti[:, 0], demo_anti[:, 1], color=c_anti, lw=2, label='Anti-S demo')
+        ax.set_title(title, fontsize=11)
+        ax.set_xlabel('x')
+        ax.set_aspect('equal')
+        ax.grid(True, alpha=0.3)
+
+    # DP generated
+    for traj in dp_trajs:
+        axes[1].plot(traj[:, 0], traj[:, 1], color=c_gen, alpha=0.3, lw=0.8)
+
+    # SFP generated
+    for traj in sfp_trajs:
+        axes[2].plot(traj[:, 0], traj[:, 1], color=c_gen, alpha=0.3, lw=0.8)
+
+    # SFP + EqM-E generated
+    for traj in eqme_trajs:
+        axes[3].plot(traj[:, 0], traj[:, 1], color=c_gen, alpha=0.3, lw=0.8)
+
+    axes[0].set_ylabel('y')
+
+    # Legend
+    legend_elements = [
+        mpatches.Patch(color=c_s,   label='S-curve demo'),
+        mpatches.Patch(color=c_anti, label='Anti-S demo'),
+        mpatches.Patch(color=c_gen,  label=f'Generated ({N_ROLLOUTS} samples)'),
+    ]
+    fig.legend(handles=legend_elements, loc='lower center', ncol=3,
+               bbox_to_anchor=(0.5, -0.02), fontsize=10)
+
+    plt.tight_layout(rect=[0, 0.06, 1, 1])
+    out_path = 'toy_2d_comparison.png'
+    plt.savefig(out_path, dpi=150, bbox_inches='tight')
+    print(f"\nSaved comparison plot → {out_path}")
+    plt.show()
+
+
+if __name__ == '__main__':
+    main()

--- a/streaming_flow_policy/pusht/sfps.py
+++ b/streaming_flow_policy/pusht/sfps.py
@@ -17,6 +17,7 @@ class StreamingFlowPolicyStochastic (Policy):
                  σ0: float = 0.0,
                  σ1: float = 0.0,
                  pred_horizon: int = 16,
+                 eqme_lambda: float = 0.0,
                  device: torch.device = 'cuda',
         ):
         """
@@ -42,6 +43,8 @@ class StreamingFlowPolicyStochastic (Policy):
             pred_horizon (int): prediction horizon
             σ0 (float): standard deviation of conditional probability flow at t=0.
             σ1 (float): standard deviation of conditional probability flow at t=1.
+            eqme_lambda (float): weight for the EqM-E regularisation loss.
+                Set to 0 (default) to disable.
             device (torch.device): device
         """
         super().__init__()
@@ -57,7 +60,9 @@ class StreamingFlowPolicyStochastic (Policy):
         self.register_buffer('σ0', torch.tensor(σ0, dtype=torch.float32))
         self.register_buffer('σ1', torch.tensor(σ1, dtype=torch.float32))
         self.register_buffer('σr', torch.tensor(σr, dtype=torch.float32))
+        self.register_buffer('eqme_lambda', torch.tensor(eqme_lambda, dtype=torch.float32))
         self.pred_horizon: Tensor; self.σ0: Tensor; self.σ1: Tensor; self.σr: Tensor
+        self.eqme_lambda: Tensor
 
     def TransformTrainingDatum(self, datum: Dict[str, np.ndarray]) -> Dict[str, np.ndarray]:
         """
@@ -126,6 +131,7 @@ class StreamingFlowPolicyStochastic (Policy):
             'va': va.astype(np.float32),  # (1, ACTION_DIM)
             'vz': vz.astype(np.float32),  # (1, ACTION_DIM)
             't': time,  # (,)
+            'xi_t': ξt.astype(np.float32),  # (1, ACTION_DIM) clean trajectory point
         }
 
     @torch.enable_grad()
@@ -133,39 +139,76 @@ class StreamingFlowPolicyStochastic (Policy):
         """
         Args:
             batch (Dict[str, Tensor]):
-                'obs' (Tensor, shape=(B, OBS_HORIZON, OBS_DIM))
-                'a' (Tensor, shape=(B, 1, ACTION_DIM))
-                'z' (Tensor, shape=(B, 1, ACTION_DIM), dtype=np.float32): latent variable
-                'va' (Tensor, shape=(B, 1, ACTION_DIM), dtype=np.float32): target a-velocity
-                'vz' (Tensor, shape=(B, 1, ACTION_DIM), dtype=np.float32): target z-velocity
-                't' (Tensor, shape=(B,)): time
+                'obs'   (Tensor, shape=(B, OBS_HORIZON, OBS_DIM))
+                'a'     (Tensor, shape=(B, 1, ACTION_DIM)): noisy action sample
+                'z'     (Tensor, shape=(B, 1, ACTION_DIM)): latent variable
+                'va'    (Tensor, shape=(B, 1, ACTION_DIM)): target a-velocity
+                'vz'    (Tensor, shape=(B, 1, ACTION_DIM)): target z-velocity
+                't'     (Tensor, shape=(B,)): time
+                'xi_t'  (Tensor, shape=(B, 1, ACTION_DIM)): clean trajectory point ξ(t)
 
         Returns:
-            Tensor (shape=(,), dtype=torch.float32): loss
+            Tensor (shape=(,), dtype=torch.float32): total loss
         """
         # device transfer
-        obs = batch['obs'].to(self.device)  # (B, OBS_HORIZON, OBS_DIM)
-        a = batch['a'].to(self.device)  # (B, 1, ACTION_DIM)
-        z = batch['z'].to(self.device)  # (B, 1, ACTION_DIM)
-        va = batch['va'].to(self.device)  # (B, 1, ACTION_DIM)
-        vz = batch['vz'].to(self.device)  # (B, 1, ACTION_DIM)
-        t = batch['t'].to(self.device)  # (B,)
-        B = obs.shape[0]
+        obs = batch['obs'].to(self.device)   # (B, OBS_HORIZON, OBS_DIM)
+        a = batch['a'].to(self.device)       # (B, 1, ACTION_DIM)
+        z = batch['z'].to(self.device)       # (B, 1, ACTION_DIM)
+        va = batch['va'].to(self.device)     # (B, 1, ACTION_DIM)
+        vz = batch['vz'].to(self.device)     # (B, 1, ACTION_DIM)
+        t = batch['t'].to(self.device)       # (B,)
 
         # observation as FiLM conditioning
         obs_cond = obs.flatten(start_dim=1)  # (B, OBS_HORIZON * OBS_DIM)
 
         # concatenate a and z
-        x = torch.cat((a, z), dim=-2)  # (B, 2, ACTION_DIM)
-        v_target = torch.cat((va, vz), dim=-2)  # (B, 2, ACTION_DIM)
+        x = torch.cat((a, z), dim=-2)            # (B, 2, ACTION_DIM)
+        v_target = torch.cat((va, vz), dim=-2)   # (B, 2, ACTION_DIM)
 
         # predict the velocity
         v_pred = self.velocity_net(
             sample=x, timestep=t, global_cond=obs_cond
         )  # (B, 2, ACTION_DIM)
 
-        # L2 loss
-        loss = nn.functional.mse_loss(v_pred, v_target)  # (,)
+        # SFP flow-matching loss  L_SFP = ||v_pred - v_target||^2
+        loss = nn.functional.mse_loss(v_pred, v_target)
+
+        # ------------------------------------------------------------------ #
+        # EqM-E regularisation (only when eqme_lambda > 0)
+        #
+        # Energy:      g(a, t, h) = a · v_a_theta(a, t, h)
+        # Regulariser: L_eqme = lambda * ||grad_a g||^2
+        #
+        # Evaluated at the *clean* trajectory point a = ξ(t) so the gradient
+        # penalises the vector field geometry near the demonstration manifold.
+        # ------------------------------------------------------------------ #
+        if self.eqme_lambda.item() > 0.0:
+            xi_t = batch['xi_t'].to(self.device)  # (B, 1, ACTION_DIM)
+
+            # Detach from the original graph and re-attach as a leaf so we can
+            # differentiate the network output w.r.t. this specific input.
+            xi_leaf = xi_t.detach().requires_grad_(True)  # (B, 1, ACTION_DIM)
+
+            # Forward pass at clean trajectory point, keeping the graph alive
+            # so that the higher-order gradient can be backpropagated.
+            x_clean = torch.cat((xi_leaf, z.detach()), dim=-2)  # (B, 2, ACTION_DIM)
+            v_clean = self.velocity_net(
+                sample=x_clean, timestep=t, global_cond=obs_cond.detach()
+            )  # (B, 2, ACTION_DIM)
+
+            # Action-velocity component only:  v_a shape (B, 1, ACTION_DIM)
+            v_a_clean = v_clean[:, :1, :]
+
+            # g = ξ(t) · v_a(ξ(t), z, t, h)  — summed to a scalar
+            g = (xi_leaf * v_a_clean).sum()
+
+            # grad_a g  shape (B, 1, ACTION_DIM);  create_graph=True allows
+            # higher-order differentiation through this gradient during .backward()
+            (grad_g,) = torch.autograd.grad(g, xi_leaf, create_graph=True)
+
+            l_eqme = (grad_g ** 2).mean()
+            loss = loss + self.eqme_lambda * l_eqme
+
         return loss
 
     @torch.inference_mode()


### PR DESCRIPTION
- sfps.py: add `eqme_lambda` parameter to StreamingFlowPolicyStochastic; expose clean trajectory point `xi_t` from TransformTrainingDatum; compute EqM-E loss  L = λ·||∇_a (a·v_θ)||²  at ξ(t) when λ > 0 (fully backward-compatible — existing PushT training unaffected).

- dataset_2d_toy.py: new ToyDataset2D that generates bimodal S-curve / anti-S-curve demonstrations; matches PushTStateDataset interface.

- experiments/toy_2d/train_and_plot.py: trains DP baseline, SFP, and SFP+EqM-E on the toy dataset and saves a side-by-side comparison plot (toy_2d_comparison.png) showing bimodal coverage of each method.